### PR TITLE
Ars fix delete event food

### DIFF
--- a/src/javascripts/components/eventSingleView/eventFoodDetails.js
+++ b/src/javascripts/components/eventSingleView/eventFoodDetails.js
@@ -42,7 +42,7 @@ const getEventFoodDetails = (singleEvent) => {
   domString += '</thead>';
   domString += '<tbody>';
   singleEvent.food.forEach((foodItem) => {
-    domString += `<tr class="eventFoodItem foodRow" data-id="${foodItem.id}" data-parent="${foodItem.parentEventFoodId}" data-container="${foodItem.parentEventId}">`;
+    domString += `<tr id="foodItemRow" class="eventFoodItem foodRow" data-id="${foodItem.id}" data-parent="${foodItem.parentEventFoodId}" data-container="${foodItem.parentEventId}">`;
     domString += `<th scope="row" class="cell-width">${foodItem.type}</th>`;
     domString += `<td class="cell-width">$${foodItem.price}</td>`;
     domString += `<td class="cell-width">${foodItem.parentQuantity}</td>`;

--- a/src/javascripts/components/eventSingleView/eventFoodDetails.js
+++ b/src/javascripts/components/eventSingleView/eventFoodDetails.js
@@ -28,7 +28,6 @@ const getFoodTotals = (singleEvent) => {
 
 const getEventFoodDetails = (singleEvent) => {
   let domString = '';
-  console.log('single event data used for food details', singleEvent);
   domString += '<div id="eventFoodSection" class="quad col-md-4 col-sm-12">';
   domString += '<h4 class="eventSectionTitle">Food Details</h4>';
   domString += '<table class="table-responsive table-dark table-width">';
@@ -42,7 +41,7 @@ const getEventFoodDetails = (singleEvent) => {
   domString += '</thead>';
   domString += '<tbody>';
   singleEvent.food.forEach((foodItem) => {
-    domString += `<tr id="foodItemRow" class="eventFoodItem foodRow" data-id="${foodItem.id}" data-parent="${foodItem.parentEventFoodId}" data-container="${foodItem.parentEventId}">`;
+    domString += `<tr class="eventFoodItem foodRow" data-id="${foodItem.id}" data-parent="${foodItem.parentEventFoodId}" data-container="${foodItem.parentEventId}">`;
     domString += `<th scope="row" class="cell-width">${foodItem.type}</th>`;
     domString += `<td class="cell-width">$${foodItem.price}</td>`;
     domString += `<td class="cell-width">${foodItem.parentQuantity}</td>`;
@@ -50,7 +49,7 @@ const getEventFoodDetails = (singleEvent) => {
     domString += `<td class="cell-width">$${foodItem.rowTotal}</td>`;
     const user = firebase.auth().currentUser;
     if (user.uid === singleEvent.uid) {
-      domString += '<td class="cell-width"><button id="deleteEventFoodBtn" class="btn btn-default deleteEventBtn deleteEventFoodBtn"><i class="far fa-trash-alt"></i></button></td>';
+      domString += `<td class="cell-width"><button id="deleteEventFoodBtn" class="btn btn-default deleteEventBtn deleteEventFoodBtn" data-id="${foodItem.parentEventFoodId}"><i class="far fa-trash-alt"></i></button></td>`;
     }
     domString += '</tr>';
   });

--- a/src/javascripts/components/eventSingleView/eventSingleView.js
+++ b/src/javascripts/components/eventSingleView/eventSingleView.js
@@ -141,11 +141,9 @@ const eventAnimalDetails = (singleEvent) => {
   return domString;
 };
 
-const removeEventFood = () => {
-  const eventFoodId = $('.foodRow').data('parent');
+const removeEventFood = (e) => {
+  const eventFoodId = e.target.closest('button').dataset.id;
   const eventId = $('.foodRow').data('container');
-  console.log('XXXXXXXXXevent food id that we need to delete', eventFoodId);
-  console.log('YYYYYYYYevent id that needs to refresh', eventId);
   eventFoodData.getSingleEventFood(eventFoodId)
     .then(() => {
       eventFoodData.deleteEventFood(eventFoodId)

--- a/src/javascripts/components/eventSingleView/eventSingleView.js
+++ b/src/javascripts/components/eventSingleView/eventSingleView.js
@@ -146,7 +146,7 @@ const removeEventFood = () => {
   const eventId = $('.foodRow').data('container');
   console.log('XXXXXXXXXevent food id that we need to delete', eventFoodId);
   console.log('YYYYYYYYevent id that needs to refresh', eventId);
-  eventFoodData.getSingleEventFood()
+  eventFoodData.getSingleEventFood(eventFoodId)
     .then(() => {
       eventFoodData.deleteEventFood(eventFoodId)
         .then(() => {


### PR DESCRIPTION
Note: I changed the way the button was pulling the `eventFoodId` for the record to be deleted. The rest of the delete feature seemed to work fine - it was refreshing the correct event after a delete so I did not change how we call the `eventID` in the `removeEventFood` function. 
Of course, please let me know if there are any issues with that or if I overlooked anything!!

Fixed the delete eventFood feature: 
1. Put a new dataset attribute of id on the delete (eventFood) button. (this pulled the parentEventId for the foodItem).
1. Changed the way we pull eventFoodId in the removeEventFood function - to use e.target.closest instead of just the class  - because the site was pulling the first item with that class instead of the one where the delete button was. (and the e.target.closest finds the first `button` element and gets the value from its dataset attribute of id to get the eventFoodId).
